### PR TITLE
Feature/fix list matrices

### DIFF
--- a/minkf/methods.py
+++ b/minkf/methods.py
@@ -180,8 +180,6 @@ def run_smoother(y, x0, Cest0, M, K, Q, R, u=None):
 
     # backward recursion
     for i in range(nobs-2, -1, -1):
-        # REVIEW: Is it correct to take the i+1'th item of Mlist?
-        # I think it is according to the RTS-smoother section in Wikipedia.
         G = utils.rsolve(Cp[i+1], Cest[i].dot(Mlist[i+1].T))
         xs[i] = xest[i] + G.dot(xs[i+1] - xp[i+1])
         Cs[i] = Cest[i] + G.dot(Cs[i+1] - Cp[i+1]).dot(G.T)

--- a/minkf/tests/test_methods.py
+++ b/minkf/tests/test_methods.py
@@ -67,3 +67,64 @@ def test_filter_and_smoother():
 
     np.testing.assert_allclose(res_smo['x'], exp_x_smo)
     np.testing.assert_allclose(res_smo['C'], exp_C_smo)
+
+    # case 3: 2d-signal, varying matrices, calculate y predictions
+    y = [np.ones(2), np.ones(2), np.ones(2)]
+
+    x0 = np.array([0.0, 0.0])
+    Cest0 = np.eye(2)
+    M = [np.eye(2), 2 * np.eye(2), 3 * np.eye(2)]
+    K = [np.eye(2), 0.1 * np.eye(2), 0.01 * np.eye(2)]
+    Q = [np.eye(2), 2 * np.eye(2), 4 * np.eye(2)]
+    R = [np.eye(2), 0.5 * np.eye(2), 0.25 * np.eye(2)]
+
+    res = kf.run_filter(
+        y, x0, Cest0, M, K, Q, R,
+        likelihood=True, predict_y=True
+    )
+    exp_x = [
+        np.array([0.66666667, 0.66666667]),
+        np.array([2.07317073, 2.07317073]),
+        np.array([7.78403477, 7.78403477])
+    ]
+    exp_C = [
+        np.array([
+            [0.66666667, 0.        ],
+            [0.        , 0.66666667]
+        ]),
+        np.array([
+            [4.26829268, 0.        ],
+            [0.        , 4.26829268]
+        ]),
+        np.array([
+            [41.70703863,  0.        ],
+            [ 0.        , 41.70703863]
+        ])
+    ]
+    np.testing.assert_allclose(res['x'], exp_x)
+    np.testing.assert_allclose(res['C'], exp_C)
+    np.testing.assert_allclose(res['loglike'], 14.444253596157939)
+
+    res_smo = kf.run_smoother(y, x0, Cest0, M, K, Q, R)
+    exp_x_smo = [
+        np.array([1.01299897, 1.01299897]),
+        np.array([2.54549641, 2.54549641]),
+        np.array([7.78403477, 7.78403477])
+    ]
+    exp_C_smo = [
+        np.array([
+            [0.6288817, 0.       ],
+            [0.       , 0.6288817]]),
+        np.array([
+            [4.20380088, 0.        ],
+            [0.        , 4.20380088]
+        ]),
+        np.array([
+            [41.70703863,  0.        ],
+            [ 0.        , 41.70703863]
+        ])
+    ]
+    np.testing.assert_allclose(res_smo['x'], exp_x_smo)
+    np.testing.assert_allclose(res_smo['C'], exp_C_smo)
+
+    return


### PR DESCRIPTION
**Failing filter / smoother with variable system matrices**

Running Kalman Filter and Smoother failed when observation / transition matrices were not constants but lists of matrices. This is now fixed. See the **REVIEW** comment regarding the RTS-smoother formulae, though.

I should remark that this is just a small fix which was probably a typo previously. Anyway, now that I had a use case, I catched the bug.

**Post scriptum**
I also added a boolean option to include observation predictions to the Kalman filter return value.